### PR TITLE
Minor changes to allow use on Linux

### DIFF
--- a/Sources/Expression.swift
+++ b/Sources/Expression.swift
@@ -32,6 +32,7 @@
 //
 
 import Foundation
+import Dispatch
 
 /// Immutable wrapper for a parsed expression
 /// Reusing the same Expression instance for multiple evaluations is more efficient


### PR DESCRIPTION
Great library!  I made a few changes to allow use on Linux.

I haven't ever run into the race condition that the `objc_sync` functions are intended to avoid.  The objc runtime isn't available on Linux, so this would require a different method to synchronize on that platform.

The lack of seamless bridging to `NSString` is one of the more polluting differences on Swift for Linux at the moment.  Hopefully that restriction will be lifted in a forthcoming release.  In any case, if you're running on Linux, you're probably not using a lot of `Any` expressions that would use `NSString` anyway.

Not sure why, but the `import Dispatch` is explicitly needed on Linux.  It's apparently not in CoreFoundation.  The import causes no harm on macOS or iOS.
