### PR TITLE
Updated package description to full SPM 4.0 syntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,5 +2,12 @@
 import PackageDescription
 
 let package = Package(
-    name: "Expression"
+    name: "Expression",
+    products: [
+        .library(name: "Expression", targets: ["Expression"]),
+    ],
+    targets: [
+        .target(name: "Expression", path: "Sources"),
+        .testTarget(name: "ExpressionTests", dependencies: ["Expression"], path: "Tests"),
+    ]
 )


### PR DESCRIPTION
I was unable to use SPM with the previous minimal package description.  I believe it was 3.0 syntax with a 4.0 header.  This update works well and tests run with 'swift test' (on MacOS).