### PR TITLE
Add lock support to Linux

### DIFF
--- a/Sources/AnyExpression.swift
+++ b/Sources/AnyExpression.swift
@@ -531,7 +531,6 @@ public struct AnyExpression: CustomStringConvertible {
 
         evaluator = {
             #if !os(Linux)
-                objc_sync_enter(box)
                  lock.lock()
             #endif
           


### PR DESCRIPTION
Dear Nick,

This patch 
1. adds support for locking on the Linux platform by using NSLock instead of objc_sync_enter and objc_sync_exit
2. Update small cross platform issue with String class. String(value) --> String(describing:value)

Please let me know if I missed anything.
Hope this finds your approval.

Best
Frank