### PR TITLE
Allow quoted expressions to start with "\\"

### DIFF
--- a/Sources/Expression.swift
+++ b/Sources/Expression.swift
@@ -1207,8 +1207,10 @@ private extension UnicodeScalarView {
             var string = scanCharacter({ "`'\"".unicodeScalars.contains($0) }) else {
             return nil
         }
-        while let part = scanCharacters({ $0 != delimiter && $0 != "\\" }) {
-            string += part
+        var part: String? = nil
+        repeat {
+            part = scanCharacters({ $0 != delimiter && $0 != "\\" })
+            string += part ?? ""
             if scanCharacter("\\"), let c = popFirst() {
                 switch c {
                 case "0":
@@ -1247,7 +1249,7 @@ private extension UnicodeScalarView {
                     string.append(Character(c))
                 }
             }
-        }
+        } while part != nil
         guard scanCharacter(delimiter) else {
             return .error(string == String(delimiter) ?
                 .unexpectedToken(string) : .missingDelimiter(String(delimiter)), string)

--- a/Tests/ExpressionTests.swift
+++ b/Tests/ExpressionTests.swift
@@ -515,6 +515,12 @@ class ExpressionTests: XCTestCase {
         XCTAssertEqual(expression.symbols, [.variable("'foo\nbar'")])
         XCTAssertEqual(expression.description, "'foo\\nbar'")
     }
+    
+    func testValidateQuotedIdentifierOfJustNewline() {
+        let expression = Expression.parse("'\\n'")
+        XCTAssertEqual(expression.symbols, [.variable("'\n'")])
+        XCTAssertEqual(expression.description, "'\\n'")
+    }
 
     func testValidateQuotedIdentifierContainingCarriageReturn() {
         let expression = Expression.parse("'foo\\rbar'")

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -610,6 +610,7 @@ extension ExpressionTests {
         ("testValidateQuotedIdentifierContainingDelete", testValidateQuotedIdentifierContainingDelete),
         ("testValidateQuotedIdentifierContainingEmoji", testValidateQuotedIdentifierContainingEmoji),
         ("testValidateQuotedIdentifierContainingNewline", testValidateQuotedIdentifierContainingNewline),
+        ("testValidateQuotedIdentifierOfJustNewline", testValidateQuotedIdentifierOfJustNewline),
         ("testValidateQuotedIdentifierContainingNull", testValidateQuotedIdentifierContainingNull),
         ("testValidateQuotedIdentifierContainingTab", testValidateQuotedIdentifierContainingTab),
         ("testValidateQuotedIdentifierContainingUnitSeparator", testValidateQuotedIdentifierContainingUnitSeparator),


### PR DESCRIPTION
This fixes an edge case if a quoted expression starts with "\\", by turning the `while ... do { ...}` into a `repeat { ... } while`.

Resolves #32 