### PR TITLE
Suppress build error

### DIFF
--- a/Benchmarks/BenchmarkUtils.swift
+++ b/Benchmarks/BenchmarkUtils.swift
@@ -262,7 +262,7 @@ func evaluateNSExpressions(_ expressions: [String]) -> NSNumber? {
     ]
 
     func makeJSContext(symbols: [String: Any]) -> JSContext {
-        let context = JSContext()
+        let context = JSContext()!
         for (key, value) in symbols {
             context.globalObject.setValue(value, forProperty: key)
         }


### PR DESCRIPTION
Creation of context needs to be force-unwrapped for Xcode 13 to build properly.